### PR TITLE
Updating statistics when hiding jp only

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,24 +138,24 @@
             <h3>All Servants</h3>
             <h4><small>Overall:</small> <em id="statisticBoxAllPercent"></em>% <small>(<span id="statisticBoxAllHave"></span>/<span id="statisticBoxAllMax"></span>)</small></h4>
             <ul>
-                <li>5★: <span id="ssrBoxAllPercent"></span>% (<span id="ssrBoxAllHave"></span>/<span id="ssrBoxAllMax"></span>)</li>
-                <li>4★: <span id="srBoxAllPercent"></span>% (<span id="srBoxAllHave"></span>/<span id="srBoxAllMax"></span>)</li>
-                <li>3★: <span id="rareBoxAllPercent"></span>% (<span id="rareBoxAllHave"></span>/<span id="rareBoxAllMax"></span>)</li>
-                <li>2★: <span id="uncommonBoxAllPercent"></span>% (<span id="uncommonBoxAllHave"></span>/<span id="uncommonBoxAllMax"></span>)</li>
-                <li>1★: <span id="commonBoxAllPercent"></span>% (<span id="commonBoxAllHave"></span>/<span id="commonBoxAllMax"></span>)</li>
-                <li>0✩: <span id="noneBoxAllPercent"></span>% (<span id="noneBoxAllHave"></span>/<span id="noneBoxAllMax"></span>)</li>
+                <li id="ssrBoxAllStats"></li>
+                <li id="srBoxAllStats"></li>
+                <li id="rareBoxAllStats"></span></li>
+                <li id="uncommonBoxAllStats"></li>
+                <li id="commonBoxAllStats"></li>
+                <li id="noneBoxAllStats"></li>
             </ul>
         </div>
         <div class="col statsColumn">
             <h3>Excluding Welfares</h3>
             <h4><small>Overall:</small> <em id="statisticBoxNotEventPercent"></em>% <small>(<span id="statisticBoxNotEventHave"></span>/<span id="statisticBoxNotEventMax"></span>)</small></h4>
             <ul>
-                <li>5★: <span id="ssrBoxNotEventPercent"></span>% (<span id="ssrBoxNotEventHave"></span>/<span id="ssrBoxNotEventMax"></span>)</li>
-                <li>4★: <span id="srBoxNotEventPercent"></span>% (<span id="srBoxNotEventHave"></span>/<span id="srBoxNotEventMax"></span>)</li>
-                <li>3★: <span id="rareBoxNotEventPercent"></span>% (<span id="rareBoxNotEventHave"></span>/<span id="rareBoxNotEventMax"></span>)</li>
-                <li>2★: <span id="uncommonBoxNotEventPercent"></span>% (<span id="uncommonBoxNotEventHave"></span>/<span id="uncommonBoxNotEventMax"></span>)</li>
-                <li>1★: <span id="commonBoxNotEventPercent"></span>% (<span id="commonBoxNotEventHave"></span>/<span id="commonBoxNotEventMax"></span>)</li>
-                <li>0✩: <span id="noneBoxNotEventPercent"></span>% (<span id="noneBoxNotEventHave"></span>/<span id="noneBoxNotEventMax"></span>)</li>
+                <li id="ssrBoxNotEventStats"></li>
+                <li id="srBoxNotEventStats"></li>
+                <li id="rareBoxNotEventStats"></li>
+                <li id="uncommonBoxNotEventStats"></li>
+                <li id="commonBoxNotEventStats"></li>
+                <li id="noneBoxNotEventStats"></li>
             </ul>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -132,34 +132,34 @@
             </div>
         </div>
     </div>
-    <h3 align="center" id="statsTitle">Stats for nerds (values include JP-only Servants even if you hide them):</h3>
-    <div class="row statsBox" id="statisticBox" style="display:none;">
-        <div class="col statsColumn padoru_text">
-            <h3>All Servants</h3>
-            <h4><small>Overall:</small> <em id="statisticBoxAllPercent"></em>% <small>(<span id="statisticBoxAllHave"></span>/<span id="statisticBoxAllMax"></span>)</small></h4>
-            <ul>
-                <li id="ssrBoxAllStats"></li>
-                <li id="srBoxAllStats"></li>
-                <li id="rareBoxAllStats"></span></li>
-                <li id="uncommonBoxAllStats"></li>
-                <li id="commonBoxAllStats"></li>
-                <li id="noneBoxAllStats"></li>
-            </ul>
-        </div>
-        <div class="col statsColumn">
-            <h3>Excluding Welfares</h3>
-            <h4><small>Overall:</small> <em id="statisticBoxNotEventPercent"></em>% <small>(<span id="statisticBoxNotEventHave"></span>/<span id="statisticBoxNotEventMax"></span>)</small></h4>
-            <ul>
-                <li id="ssrBoxNotEventStats"></li>
-                <li id="srBoxNotEventStats"></li>
-                <li id="rareBoxNotEventStats"></li>
-                <li id="uncommonBoxNotEventStats"></li>
-                <li id="commonBoxNotEventStats"></li>
-                <li id="noneBoxNotEventStats"></li>
-            </ul>
-        </div>
-    </div>
+    <h3 align="center" id="statsTitle">Stats for nerds:</h3>
     <div id="capturearea">
+        <div class="row statsBox" id="statisticBox" style="display:none;">
+            <div class="col statsColumn padoru_text">
+                <h3>All Servants</h3>
+                <h4><small>Overall:</small> <em id="statisticBoxAllPercent"></em>% <small>(<span id="statisticBoxAllHave"></span>/<span id="statisticBoxAllMax"></span>)</small></h4>
+                <ul>
+                    <li id="ssrBoxAllStats"></li>
+                    <li id="srBoxAllStats"></li>
+                    <li id="rareBoxAllStats"></span></li>
+                    <li id="uncommonBoxAllStats"></li>
+                    <li id="commonBoxAllStats"></li>
+                    <li id="noneBoxAllStats"></li>
+                </ul>
+            </div>
+            <div class="col statsColumn">
+                <h3>Excluding Welfares</h3>
+                <h4><small>Overall:</small> <em id="statisticBoxNotEventPercent"></em>% <small>(<span id="statisticBoxNotEventHave"></span>/<span id="statisticBoxNotEventMax"></span>)</small></h4>
+                <ul>
+                    <li id="ssrBoxNotEventStats"></li>
+                    <li id="srBoxNotEventStats"></li>
+                    <li id="rareBoxNotEventStats"></li>
+                    <li id="uncommonBoxNotEventStats"></li>
+                    <li id="commonBoxNotEventStats"></li>
+                    <li id="noneBoxNotEventStats"></li>
+                </ul>
+            </div>
+        </div>
         <div class="card" style="margin-top: 10px;">
             <div class="card-header bg-warning header-shadow">5★ SSR</div>
             <div class="card-body">
@@ -300,7 +300,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary" onclick="updateUserData()">Save changes</button>
+        <button type="button" class="btn btn-primary" onclick="updateUnitData()">Save changes</button>
       </div>
     </div>
   </div>

--- a/js/index.js
+++ b/js/index.js
@@ -995,8 +995,7 @@ function updateStatisticsHTML() {
     const classMap = new Map([
         ["ssrBox", "5★"], ["srBox", "4★"], ["rareBox", "3★"], ["uncommonBox", "2★"], ["commonBox", "1★"], ["noneBox", "0✩"]
     ]);
-    var overallTotal = 0;
-    var overallOwned = 0;
+    var overallTotal = 0, overallOwned = 0, overallPercent = 0;
     [...$('.row.listbox')].forEach(box => {
         var $container = $(box);
         var boxType = $container.attr('id');
@@ -1008,8 +1007,7 @@ function updateStatisticsHTML() {
         var totalAll = classMap.get(boxType) + ": " + percentageOwned.toFixed(2) + "% (" + ownedUnits + "/" + totalUnits + ")";
         $("#" + boxType + "AllStats").text(totalAll);
     });
-    var overallNotEventTotal = 0;
-    var overallNotEventOwned = 0;
+    var overallNotEventTotal = 0, overallNotEventOwned = 0, overallNotEventPercent = 0;
     [...$('.row.listbox')].forEach(box => {
         var $container = $(box);
         var boxType = $container.attr('id');
@@ -1027,6 +1025,14 @@ function updateStatisticsHTML() {
             "/" + totalNonEventUnits + ")";
         $("#" + boxType + "NotEventStats").text(totalNotEvent);
     });
+    overallPercent = ((overallOwned / overallTotal) * 100).toFixed(2);
+    overallNotEventPercent = ((overallNotEventOwned / overallNotEventTotal) * 100).toFixed(2);
+    $("#statisticBoxAllPercent").text(overallPercent);
+    $("#statisticBoxAllHave").text(overallOwned);
+    $("#statisticBoxAllMax").text(overallTotal);
+    $("#statisticBoxNotEventPercent").text(overallNotEventPercent);
+    $("#statisticBoxNotEventHave").text(overallNotEventOwned);
+    $("#statisticBoxNotEventMax").text(overallNotEventTotal);
 }
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -989,60 +989,44 @@ function buildUnitDataInUI(units_data) {
 }
 
 /**
- * Updates the statistics section of the displayed page based on selected data.
+ * Updates the statistics section of the displayed page based on displayed selected data.
  */
 function updateStatisticsHTML() {
-    var all_base = 0; // Prepare Temp Int
-    for (var key in own_data) {
-        if (own_data.hasOwnProperty(key)) { all_base += own_data[key].length; }
-    }
-    var all_base_NotEvent = 0;
-    for (var key in own_data_notevent) {
-        if (own_data_notevent.hasOwnProperty(key)) {
-            all_base_NotEvent += own_data_notevent[key].length;
-        }
-    }
-    // All Rarity
-    var AllPercent = Number(all_base / rarity_count_data.allcount.max * 100);
-    $("#" + statistic_area + "AllMax").html(rarity_count_data.allcount.max);
-    $("#" + statistic_area + "AllHave").html(all_base);
-    $("#" + statistic_area + "AllPercent").html(parseFloat(Math.round(AllPercent * 100) / 100).toFixed(2));
-    var NotEventPercent = Number(all_base_NotEvent / rarity_count_data.noteventcount.max * 100);
-    $("#" + statistic_area + "NotEventMax").html(rarity_count_data.noteventcount.max);
-    $("#" + statistic_area + "NotEventHave").html(all_base_NotEvent);
-    $("#" + statistic_area + "NotEventPercent").html(parseFloat(Math.round(NotEventPercent * 100) / 100).toFixed(2));
-    // Each Rarity
-    for (var prop in rarity_count_data.allcount.list) {
-        if(!rarity_count_data.allcount.list.hasOwnProperty(prop)) { continue; } // skip loop if the property is from prototype
-        var rarity_base = 0; // Prepare Temp Int
-        if (own_data.hasOwnProperty(prop)) { rarity_base = own_data[prop].length; }
-        var rarity_base_NotEvent = 0;
-        if (own_data_notevent.hasOwnProperty(prop)) { rarity_base_NotEvent = own_data_notevent[prop].length; }
-        // all & notevent
-        var r_allcount = rarity_count_data.allcount.list[prop];
-        var r_AllPercent = Number(rarity_base / r_allcount.max * 100);
-        $("#" + r_allcount.list_element + "AllMax").html(r_allcount.max);
-        $("#" + r_allcount.list_element + "AllHave").html(rarity_base);
-        $("#" + r_allcount.list_element + "AllPercent").html(parseFloat(Math.round(r_AllPercent * 100) / 100).toFixed(2));
-        var r_noteventcount = rarity_count_data.noteventcount.list[prop];
-        var r_NotEventPercent = Number(rarity_base_NotEvent / r_noteventcount.max * 100);
-        $("#" + r_noteventcount.list_element + "NotEventMax").html(r_noteventcount.max);
-        $("#" + r_noteventcount.list_element + "NotEventHave").html(rarity_base_NotEvent);
-        $("#" + r_noteventcount.list_element + "NotEventPercent").html(parseFloat(Math.round(r_NotEventPercent * 100) / 100).toFixed(2));
-    }
-    // Class
-    for (var curr_rare in max_data_eachclass) {
-        for (var curr_class in max_data_eachclass[curr_rare]) {
-            var curr_class_have = 0;
-            if (own_data_eachclass.hasOwnProperty(curr_rare)) {
-                if (own_data_eachclass[curr_rare].hasOwnProperty(curr_class)) {
-                    curr_class_have = own_data_eachclass[curr_rare][curr_class].length;
-                }
-            }
-            $("#" + class_count_have + curr_rare + "_" + curr_class).html(curr_class_have);
-            $("#" + class_count_max + curr_rare + "_" + curr_class).html(max_data_eachclass[curr_rare][curr_class]);
-        }
-    }
+    const classMap = new Map([
+        ["ssrBox", "5★"], ["srBox", "4★"], ["rareBox", "3★"], ["uncommonBox", "2★"], ["commonBox", "1★"], ["noneBox", "0✩"]
+    ]);
+    var overallTotal = 0;
+    var overallOwned = 0;
+    [...$('.row.listbox')].forEach(box => {
+        var $container = $(box);
+        var boxType = $container.attr('id');
+        var totalUnits = $container.find('.member-container').length;
+        overallTotal += totalUnits;
+        var ownedUnits = $container.find('.member-container.member-checked').length;
+        overallOwned += ownedUnits;
+        var percentageOwned = (ownedUnits / totalUnits) * 100;
+        var totalAll = classMap.get(boxType) + ": " + percentageOwned.toFixed(2) + "% (" + ownedUnits + "/" + totalUnits + ")";
+        $("#" + boxType + "AllStats").text(totalAll);
+    });
+    var overallNotEventTotal = 0;
+    var overallNotEventOwned = 0;
+    [...$('.row.listbox')].forEach(box => {
+        var $container = $(box);
+        var boxType = $container.attr('id');
+        var totalNonEventUnits = $container.find('.member-container').filter(function() {
+            return $(this).find('.member-eventonly').length === 0;
+        }).length;
+        overallNotEventTotal += totalNonEventUnits;
+        var ownedNonEventUnits = $container.find('.member-container.member-checked').filter(function() {
+            return $(this).find('.member-eventonly').length === 0;
+        }).length;
+        overallNotEventOwned += ownedNonEventUnits;
+        var percentageNonEventOwned = (ownedNonEventUnits / totalNonEventUnits) * 100;
+        var totalNotEvent =
+            classMap.get(boxType) + ": " + percentageNonEventOwned.toFixed(2) + "% (" + ownedNonEventUnits +
+            "/" + totalNonEventUnits + ")";
+        $("#" + boxType + "NotEventStats").text(totalNotEvent);
+    });
 }
 
 /**


### PR DESCRIPTION
- Statistics will now adjust whenever hiding JP-only units.
- Capture area for image rendering now includes statistics area again, since the values will reflect whatever is selected (NA only or everything, aka JP).