### PR TITLE
Mash fix

### DIFF
--- a/js/functionLibrary.js
+++ b/js/functionLibrary.js
@@ -957,15 +957,15 @@ function getMashSRURLstring(allowZero) {
  */
 function getNewCopySource(current_max, s_list) {
     if (current_max < Config.copy_choice_max && current_max > 0) {
-        var new_choice_allow = []; var i = 0;
+        var new_choice_allow = [], i = 0;
         for (i = 0; i < Config.copy_choice_allow.length; i++) {
             debugger;
-            if (copy_choice_allow[i].id <= current_max) {
-                new_choice_allow.push(copy_choice_allow[i]);
+            if (Config.copy_choice_allow[i].id <= current_max) {
+                new_choice_allow.push(Config.copy_choice_allow[i]);
             } else { break; }
         }
         s_list.data('select2').dataAdapter
-            .updateOptions(Config.new_choice_allow);
+            .updateOptions(new_choice_allow);
     } else
     { s_list.data('select2').dataAdapter
         .updateOptions(Config.copy_choice_allow); }

--- a/js/functionLibrary.js
+++ b/js/functionLibrary.js
@@ -959,6 +959,7 @@ function getNewCopySource(current_max, s_list) {
     if (current_max < Config.copy_choice_max && current_max > 0) {
         var new_choice_allow = []; var i = 0;
         for (i = 0; i < Config.copy_choice_allow.length; i++) {
+            debugger;
             if (copy_choice_allow[i].id <= current_max) {
                 new_choice_allow.push(copy_choice_allow[i]);
             } else { break; }
@@ -1161,10 +1162,10 @@ function loadLocalData() {
         } else {
             if (Config.encoded_user_input == null) {
                 Config.encoded_user_input = ""; // Blank out raw input
-                finishLoading();
             }
         }
     });
+    finishLoading();
 }
 
 /**


### PR DESCRIPTION
Fixed an issue when selecting Mash in normal mode (not Fast Mode) which would throw an error to the console because of incorrect member referencing.